### PR TITLE
Add Mastodon link in the info page. Add English info content.

### DIFF
--- a/backend/Instanssi/main2024/templates/main2024/english.html
+++ b/backend/Instanssi/main2024/templates/main2024/english.html
@@ -8,7 +8,8 @@
 <p>
     Instanssi is a festival of digital creativity in Jyväskylä, Finland. Instanssi is 
     a beginner-friendly event that anyone interested in digital culture can visit and enjoy.
-    Instanssi offers workshops, presentations, and a friendly creative environment.
+    Instanssi offers demoscene compos (competitions), workshops, presentations, and a friendly 
+    creative environment.
 </p>
 
 <!--
@@ -30,51 +31,72 @@
         <b>Support ticket (ökylippu)</b> – 50 Euros. For those who want to support Instanssi! This ticket allows entrance to Instanssi and a table spot for your computer. You can also say a few words at the opening ceremony if you like.
     </li>
 </ul>-->
+<h2>Time and place</h2>
+<p>
+    Instanssi 2024 is held from 29 Feb to 3 March 2024 at Voionmaankatu 18, Jyväskylä.
+</p>
+<iframe width="600"
+        height="450"
+        id="instanssi-location-map"
+        frameborder="0"
+        style="border:0; max-width:100%"
+        src="https://www.google.com/maps/embed/v1/place?q=place_id:ChIJ3WoIEiN0hUYRogdPWJx7Alk&language=en&key={{ settings.GOOGLE_API_KEY }}" allowfullscreen></iframe>
 
+<h3>Nearby services</h3>
+<p>Note that the closest K-market Ruokavinkki is no longer in operation! Here are some other nearby services:</p>
+<ul>
+    <li>Across the street: R-kioski (Voionmaankatu 15) and LaCasa pizzeria (Voionmaankatu 15 B)</li>
+    <li>400 m towards Kortepohja: Kotipizza Jyväskylä Mäki-Matti (Voionmaankatu 34)</li>
+    <li>1 km towards Kortepohja: K-Supermarket Länsiväylä (Kaivokatu 1)</li>
+    <li>800 m in city center: K-Market Kymppi (Kauppakatu 10)</li>
+    <li>The closest bus stops are right by the party place</li>
+</ul>
+<p>Ask help from infodesk if needed!</p>
 
 <h2>What do I need to take with me?</h2>
-    <p>
-        Bring the same necessities as you would to any other LAN-party or demoparty. Here is a small checklist to help you.
-    </p>
-    <ul>
-      <li>
-          If you have a ticket with a computer place, bring your computer with all the necessary accessories. Bring a long power cord and your own extension cord. Remember to write your name on your stuff!
-      </li>
-      <li>A sleeping bag and pad</li>
-      <li>Change of clothes</li>
-      <li>Personal toiletries: towel, toothbrush etc. There is a shower on the venue.</li>
-      <li>Cash if you are buying your tickets from the door</li>
-      <li>Your own mug for free coffee and tea</li>
-      <li>
-        Snacks and non-alcoholic beverages. There is a microwave oven, a coffee maker, and a kettle for free use on the venue. Fridge space is limited, so bring your own cooler (Peltier coolers allowed). 
-      </li>
-      <li>Demoparty vibes!</li>
-    </ul>
+<p>
+    Bring the same necessities as you would to any other LAN-party or demoparty. Here is a small checklist to help you.
+</p>
+<ul>
+    <li>
+        If you have a ticket with a computer place, bring your computer with all the necessary accessories. Bring a long power cord and your own extension cord. Remember to write your name on your stuff!
+    </li>
+    <li>A sleeping bag and pad</li>
+    <li>Change of clothes</li>
+    <li>Personal toiletries: towel, toothbrush etc. There is a shower and an outdoor sauna on the venue, so you can also bring flip-flops, a small towel to sit on, and a bathrobe.</li>
+    <li>Bank card, cash, or MobilePay for buying your tickets or t-shirts from the door</li>
+    <li>Your own mug or thermos for free coffee and tea</li>
+    <li>
+        Snacks and non-alcoholic beverages and utensils. There is a microwave oven, a coffee maker, and a kettle for free use on the venue. Fridge space is limited, so bring your own cooler (Peltier coolers allowed). 
+    </li>
+    <li>Demoparty vibes!</li>
+</ul>
 
-    <h2>What NOT to bring</h2>
-    <p>A list of forbidden items</p>
-    <ul>
-        <li>Prescription drugs without a prescription slip and ID</li>
-        <li>Alcohol</li>
-        <li>Narcotics</li>
-        <li>Firearms, edge tools, and other possibly harming objects.</li>
-        <li>Multifunctional tools</li>
-        <li>Fireworks and other explosives</li>
-        <li>Laser pointers and similar objects</li>
-        <li>Own domestic appliances (Fridges, coffee makers, washing machines etc.)</li>
-    </ul>
+<h2>What NOT to bring</h2>
+<p>A list of forbidden items</p>
+<ul>
+    <li>Prescription drugs without a prescription slip and ID</li>
+    <li>Alcohol</li>
+    <li>Narcotics</li>
+    <li>Firearms, edge tools, and other possibly harming objects.</li>
+    <li>Multifunctional tools</li>
+    <li>Fireworks and other explosives</li>
+    <li>Laser pointers and similar objects</li>
+    <li>Own domestic appliances (Fridges, coffee makers, washing machines etc.)</li>
+</ul>
 
-    <h2>Chat</h2>
-    <p>
-        Matrix: <a href="https://matrix.to/#/#instanssi:hacklab.fi">#instanssi:hacklab.fi</a><br />
-        Telegram: <a href="https://telegram.me/Instanssi">https://telegram.me/Instanssi</a><br /><br />
-	These are chat rooms are bridged, so you can pick your favourite chat platform!
-    </p>
-    
-    <h2>Social media</h2>
-    <p>
-        Twitter: <a href="https://twitter.com/instanssi">https://twitter.com/instanssi</a><br />
-        Facebook: <a href="https://www.facebook.com/instanssi">https://www.facebook.com/instanssi</a><br />
-        Youtube: <a href="https://www.youtube.com/user/InstanssiOrg">https://www.youtube.com/user/InstanssiOrg</a>
-    </p>
+<h2>Chat</h2>
+<p>
+    Matrix: <a href="https://matrix.to/#/#instanssi:hacklab.fi">#instanssi:hacklab.fi</a><br />
+    Telegram: <a href="https://telegram.me/Instanssi">https://telegram.me/Instanssi</a><br /><br />
+These are chat rooms are bridged, so you can pick your favourite chat platform!
+</p>
+
+<h2>Social media</h2>
+<p>
+    Mastodon: <a href="https://mementomori.social/@instanssi">https://mementomori.social/@instanssi</a><br />
+    Twitter: <a href="https://twitter.com/instanssi">https://twitter.com/instanssi</a><br />
+    Facebook: <a href="https://www.facebook.com/instanssi">https://www.facebook.com/instanssi</a><br />
+    Youtube: <a href="https://www.youtube.com/user/InstanssiOrg">https://www.youtube.com/user/InstanssiOrg</a>
+</p>
 {% endblock %}

--- a/backend/Instanssi/main2024/templates/main2024/info.html
+++ b/backend/Instanssi/main2024/templates/main2024/info.html
@@ -83,6 +83,7 @@
     
     <h2>Some</h2>
     <p>
+        Mastodon: <a href="https://mementomori.social/@instanssi">https://mementomori.social/@instanssi</a><br />  
         Twitter: <a href="https://twitter.com/instanssi">https://twitter.com/instanssi</a><br />
         Facebook: <a href="https://www.facebook.com/instanssi">https://www.facebook.com/instanssi</a><br />
         Youtube: <a href="https://www.youtube.com/user/InstanssiOrg">https://www.youtube.com/user/InstanssiOrg</a>


### PR DESCRIPTION
- Adds Mastodon link in the Finnish info page and in the "In English" page.
- Adds the following info in the "In English" page: 
  - Time and place, 
  - embedded Google map (the URL is the same except the part `language=en`),
  - Nearby services
- Modifies the what to bring and not to bring lists to match with the Finnish version
- Formats whitespace in the `english.html` template