### PR TITLE
Blog pagination

### DIFF
--- a/backend/Instanssi/ext_blog/templates/ext_blog/blog_messages.html
+++ b/backend/Instanssi/ext_blog/templates/ext_blog/blog_messages.html
@@ -2,11 +2,23 @@
 <div id="blog">
 {% for entry in entries %}
     <div class="message" id="{{ entry.id }}">
+        {# TODO These links won't work if entry is not on currently shown page. Fix by adding a separate view. #}
         <a style="text-decoration: none;" href="#{{ entry.id }}"><h2>{{ entry.title }}</h2></a>
         <time datetime="{{ entry.date|date:"Y-m-d\TH:i" }}" class="date">{{ entry.date|date:"d.m.Y H:i" }}</time>
         <div class="content">{{ entry.text|safe }}</div>
     </div>
 {% endfor %}
+{% if needs_pagination %}
+    <ul class="pagination">
+        {% for i in page_range %}
+            {% if i == page_number %}
+                <li class="active" aria-label="Nykyinen sivu: {{ i }}/{{ num_pages }}"><a>{{ i }}</a></li>
+            {% else %}
+                <li><a href="?p={{ i }}" aria-label="Siirry sivulle: {{ i }}/{{ num_pages }}">{{ i }}</a></li>
+            {% endif %}
+        {% endfor %}
+    </ul>
+{% endif %}
 </div>
 {% else %}
 <p>Blogissa ei ole entryjä!</p>

--- a/backend/Instanssi/ext_blog/templatetags/blog_tags.py
+++ b/backend/Instanssi/ext_blog/templatetags/blog_tags.py
@@ -1,10 +1,25 @@
 from django import template
+from django.core.paginator import Paginator
 
 from Instanssi.ext_blog.models import BlogEntry
 
 register = template.Library()
 
 
-@register.inclusion_tag("ext_blog/blog_messages.html")
-def render_blog(event_id: int, max_posts: int = 10) -> dict:
-    return {"entries": BlogEntry.get_latest().filter(event_id=event_id)[:max_posts]}
+@register.inclusion_tag("ext_blog/blog_messages.html", takes_context=True)
+def render_blog(context, event_id: int, max_posts: int = 10) -> dict:
+    request = context["request"]
+    page_number = request.GET.get('p', 1) # Default to page 1 if get parameter is missing
+    # Make sure the page number from the get parameter is a valid integer:
+    try:
+        page_number = int(page_number)
+    except ValueError:
+        page_number = 1
+    full_entries_list = BlogEntry.get_latest().filter(event_id=event_id)
+    paginator = Paginator(full_entries_list, max_posts)
+    current_page = paginator.get_page(page_number)
+    entries = current_page.object_list
+    # We will pass this boolean as extra data to the template for simplicity
+    # It's used to determine whether to render pagination links or not:
+    needs_pagination = paginator.count > paginator.per_page
+    return {"entries": entries, "needs_pagination": needs_pagination, "page_range": paginator.page_range, "page_number": current_page.number, "num_pages": paginator.num_pages}

--- a/backend/README.md
+++ b/backend/README.md
@@ -18,12 +18,15 @@ Installing stuff for development
 1. Install the dependencies and clone this project.
 2. Copy `settings.py-dist` to `settings.py`. Change as needed. `settings.py` should never be added to
    git, as it may contain secrets.
-3. Set up environment with poetry `poetry env use 3.11`.
+3. Set up environment with poetry `poetry env use 3.11` (run inside the `backend/` directory).
 4. Install packages with poetry `poetry install --no-root --sync`.
-5. Make sure your database is set up and configured in settings.py, and then run database
+5. Switch over to a poetry shell by running `poetry shell` to have the virtual
+   environment in use for the rest of the commands. Alternatively you can add
+   `poetry run` before every command.
+6. Make sure your database is set up and configured in settings.py, and then run database
    migrations to set up initial data `python manage.py migrate`.
-6. Create a superuser so that you can access the admin `python manage.py createsuperuser`.
-7. That's all. Now just start local dev server by running `python manage.py runserver`.
+7. Create a superuser so that you can access the admin `python manage.py createsuperuser`.
+8. That's all. Now just start local dev server by running `python manage.py runserver`.
 
 Note that some background operations use celery. It can be started with following:
 `python -m celery -A Instanssi worker -l info --autoscale 2,1`


### PR DESCRIPTION
Initial version of the blog pagination. This uses a GET parameter "p" for page number (like https://instanssi.org/2024/?p=2 if there are over 10 blog entries)

This gets the basic job of pagination done.

![pagination-screenshot](https://github.com/Instanssi/Instanssi.org/assets/1404973/00388a2f-5cc5-47ab-a3f7-f769684ee559)

### URLs to individual blog entries to be fixed in the future:

Linking to individual blog entry with its id on the URL (like https://instanssi.org/2024/#1) is not very good. If the blog entry is later on another page (because newer entries are added and it falls to another page) then old enough URLs (in social media) will become non-functional when the element with the certain id (1 in this example) does not exist on the first page (default) anymore.

We will need to address this case of linking to an individual blog entry separately with a different view. Then just link to that view's URL instead of using the HTML element id in the URL and the problem goes away.

Another option to fix the case would be to invert the page numbering so the first 10 ids would always be on page nr 1 and not the latest 10 on page nr 1. Then the default page would be whatever was the highest page number. Also the initial page load would need to set the p GET parameter correctly for links to entries to work also in the future (the user would copy the whole thing like ?p=1#1 from the address bar).
However, most likely the first option is still the best and the most logical solution to use in here. We will want to have that "read a single blog post" view anyway.