### PR TITLE
main2026: Fix ability to scroll horizontally on mobile due to header overflow

### DIFF
--- a/backend/Instanssi/main2026/static/main2026/css/_header.scss
+++ b/backend/Instanssi/main2026/static/main2026/css/_header.scss
@@ -228,6 +228,9 @@
     @media screen and (max-width: $screen-sm-max) {
         height: auto;
 
+        overflow-x: hidden;
+        max-width: 100vw;
+
         & > .container, .header-info, .header-title {
             height: 155px;
         }


### PR DESCRIPTION
Should probably take the graphics out of the header structure. This should fix the immediate problem, at least.