### PR TITLE
main2026: Fix stream embed

### DIFF
--- a/backend/Instanssi/main2026/templates/main2026/stream.html
+++ b/backend/Instanssi/main2026/templates/main2026/stream.html
@@ -5,7 +5,7 @@
 <h1>Stream</h1>
 <div id="live">
     <iframe
-        src="https://player.twitch.tv/?channel=instanssi"
+        src="https://player.twitch.tv/?channel=instanssi&parent=instanssi.org"
         height="338"
         width="600"
         frameborder="0"


### PR DESCRIPTION
Not sure when Twitch started actually requiring the parent domain in the URL.